### PR TITLE
Simple customization for loading view

### DIFF
--- a/lib/src/presentation/aad_b2c_webview.dart
+++ b/lib/src/presentation/aad_b2c_webview.dart
@@ -22,6 +22,8 @@ class ADB2CEmbedWebView extends StatefulWidget {
   final List<String> scopes;
   final String responseType;
   final List<OptionalParam> optionalParameters;
+  final Widget? loadingReplacement;
+  final Color? webViewBackgroundColor;
 
   const ADB2CEmbedWebView({
     super.key,
@@ -39,6 +41,8 @@ class ADB2CEmbedWebView extends StatefulWidget {
     // Optionals
     this.onRedirect,
     this.onAnyTokenRetrieved,
+    this.loadingReplacement,
+    this.webViewBackgroundColor,
 
     // Optionals with default value
     this.responseType = Constants.defaultResponseType,
@@ -52,6 +56,7 @@ class ADB2CEmbedWebViewState extends State<ADB2CEmbedWebView> {
   final PkcePair pkcePairInstance = PkcePair.generate();
   final _key = UniqueKey();
   late Function onRedirect;
+  Widget? loadingReplacement;
 
   bool isLoading = true;
   bool showRedirect = false;
@@ -62,6 +67,7 @@ class ADB2CEmbedWebViewState extends State<ADB2CEmbedWebView> {
         () {
           Navigator.of(context).pop();
         };
+    loadingReplacement = widget.loadingReplacement;
 
     //Enable virtual display.
     if (Platform.isAndroid) WebView.platform = AndroidWebView();
@@ -155,6 +161,7 @@ class ADB2CEmbedWebViewState extends State<ADB2CEmbedWebView> {
       body: Stack(
         children: <Widget>[
           WebView(
+            backgroundColor: widget.webViewBackgroundColor,
             key: _key,
             debuggingEnabled: true,
             initialUrl: getUserFlowUrl(
@@ -171,20 +178,24 @@ class ADB2CEmbedWebViewState extends State<ADB2CEmbedWebView> {
             },
           ),
           Visibility(
-            visible: (isLoading || showRedirect),
-            child: const Center(
-              child: SizedBox(
-                height: 250,
-                width: 250,
-                child: CircularProgressIndicator(
-                  backgroundColor: Colors.white,
-                  valueColor: AlwaysStoppedAnimation<Color>(Colors.blue),
-                ),
-              ),
-            ) 
-          ),
+              visible:
+                  loadingReplacement != null && (isLoading || showRedirect),
+              child: loadingReplacement ?? const SizedBox ()),
           Visibility(
-            visible: isLoading,
+              visible:
+                  loadingReplacement == null && (isLoading || showRedirect),
+              child: const Center(
+                child: SizedBox(
+                  height: 250,
+                  width: 250,
+                  child: CircularProgressIndicator(
+                    backgroundColor: Colors.white,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.blue),
+                  ),
+                ),
+              )),
+          Visibility(
+            visible: loadingReplacement == null && isLoading,
             child: const Positioned(
               child: Center(
                 child: Text('Redirecting to Secure Login...'),


### PR DESCRIPTION
Added two optional parameters for ADB2CEmbedWebView to allow customization:
- loadingReplacement - to replace default loading indicator widgets
- webViewBackgroundColor - to change default webView background color

Giving possibility of customization like this will allow fitting loading view in app specific style.