### PR TITLE
Update aad_b2c_webview.dart

### DIFF
--- a/lib/src/presentation/aad_b2c_webview.dart
+++ b/lib/src/presentation/aad_b2c_webview.dart
@@ -247,12 +247,7 @@ class ADB2CEmbedWebViewState extends State<ADB2CEmbedWebView> {
 
   /// Creates a string representation of the scopes.
   String createScopes(List<String> scopeList) {
-    String allScope = '';
-    for (String scope in scopeList) {
-      scope += '%20';
-      allScope += scope;
-    }
-    return allScope.substring(0, allScope.length - 3);
+    return scopeList.join(' ');
   }
 
   /// Concatenates the user flow URL with additional parameters.


### PR DESCRIPTION
There is a bug on line  https://github.com/microsoft/aad_b2c_webview/blob/main/lib/src/presentation/aad_b2c_webview.dart#L164 that results in an error from Azure AD B2C. If the default scope is applied, then you use a space-separated list which plays nicely. However, if you set up custom scope, then you use url-encoded space-separated list which results in a failure. The provided fix works with custom scopes. 