### PR TITLE
Matching method signatures for onRedirect and onErrorOrCancel

### DIFF
--- a/lib/src/presentation/aad_b2c_webview.dart
+++ b/lib/src/presentation/aad_b2c_webview.dart
@@ -58,8 +58,8 @@ class ADB2CEmbedWebViewState extends State<ADB2CEmbedWebView> {
   final _key = UniqueKey();
   final PkcePair pkcePairInstance = PkcePair.generate();
   WebViewController? controller;
-  late Function onRedirect;
-  late Function onErrorOrCancel;
+  late Function(BuildContext context) onRedirect;
+  late Function(BuildContext context) onErrorOrCancel;
   Widget? loadingReplacement;
 
   bool isLoading = true;
@@ -69,11 +69,11 @@ class ADB2CEmbedWebViewState extends State<ADB2CEmbedWebView> {
   void initState() {
     super.initState();
     onRedirect = widget.onRedirect ??
-        () {
+        (context) {
           Navigator.of(context).pop();
         };
     onErrorOrCancel = widget.onErrorOrCancel ??
-            () {
+        (context) {
           Navigator.of(context).pop();
         };
     loadingReplacement = widget.loadingReplacement;


### PR DESCRIPTION
Default signatures of onRedirect and onErrorOrCancel inside ADB2CEmbedWebViewState had no context argument, like in widget part of ADB2CEmbedWebView. When using the ADB2CEmbedWebView widget without defining onRedirect it will use the default invalid method, which causes an error:

```
════════ Exception caught by services library ══════════════════════════════════
The following NoSuchMethodError was thrown during a platform message callback:
Closure call with mismatched arguments: function 'ADB2CEmbedWebViewState.initState.<anonymous closure>'
Receiver: Closure: () => Null
Tried calling: ADB2CEmbedWebViewState.initState.<anonymous closure>(Instance of 'StatefulElement')
Found: ADB2CEmbedWebViewState.initState.<anonymous closure>() => Null

When the exception was thrown, this was the stack:
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:38:5)
object_patch.dart:38
#1      _objectNoSuchMethod (dart:core-patch/object_patch.dart:85:9)
object_patch.dart:85
#2      ADB2CEmbedWebViewState.onPageFinishedTasks (package:aad_b2c_webview/src/presentation/aad_b2c_webview.dart:204:24)
aad_b2c_webview.dart:204
#3      ADB2CEmbedWebViewState.initState.<anonymous closure> (package:aad_b2c_webview/src/presentation/aad_b2c_webview.dart:92:13)
aad_b2c_webview.dart:92
#4      new AndroidNavigationDelegate.<anonymous closure> (package:webview_flutter_android/src/android_webview_controller.dart:1335:19)
android_webview_controller.dart:1335
#5      WebViewClientFlutterApiImpl.doUpdateVisitedHistory (package:webview_flutter_android/src/android_webview_api_impls.dart:819:39)
android_webview_api_impls.dart:819
#6      WebViewClientFlutterApi.setup.<anonymous closure> (package:webview_flutter_android/src/android_webview.g.dart:1906:15)
android_webview.g.dart:1906
#7      BasicMessageChannel.setMessageHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:223:49)
platform_channel.dart:223
#8      _DefaultBinaryMessenger.setMessageHandler.<anonymous closure> (package:flutter/src/services/binding.dart:567:35)
binding.dart:567
#9      _invoke2 (dart:ui/hooks.dart:344:13)
hooks.dart:344
#10     _ChannelCallbackRecord.invoke (dart:ui/channel_buffers.dart:45:5)
channel_buffers.dart:45
#11     _Channel.push (dart:ui/channel_buffers.dart:135:31)
channel_buffers.dart:135
#12     ChannelBuffers.push (dart:ui/channel_buffers.dart:343:17)
channel_buffers.dart:343
#13     PlatformDispatcher._dispatchPlatformMessage (dart:ui/platform_dispatcher.dart:722:22)
platform_dispatcher.dart:722
#14     _dispatchPlatformMessage (dart:ui/hooks.dart:257:31)
hooks.dart:257
════════════════════════════════════════════════════════════════════════════════
```

It is possible to solve this issue https://github.com/microsoft/aad_b2c_webview/issues/13, because I had same problem and now it works.
