### PR TITLE
added option to pass the prompt type, it was static "login"

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -15,4 +15,8 @@ class Constants {
   static const String userFlowUrlEnding = "oauth2/v2.0/authorize";
   static const String userGetTokenUrlEnding = "oauth2/v2.0/token";
   static const defaultResponseType = "code";
+
+  static const String promptTypeLogin = "login";
+  static const String promptTypeNone = "none";
+  static const String promptTypeConsent = "consent";
 }


### PR DESCRIPTION
I added the prompt type options ("none", "login", "consent") to support edit profile policies, it was set to "login", so it forces the user to sign in before editing the profile, now you can pass the "id_token_hint" in the optional params and edit the profile directly.