### PR TITLE
Update client_authentication.dart

### DIFF
--- a/lib/src/services/client_authentication.dart
+++ b/lib/src/services/client_authentication.dart
@@ -17,13 +17,14 @@ class ClientAuthentication {
     required String tenant,
     required String policy,
     required String clientId,
+    String? providedScopes = Constants.defaultScopes,
   }) async {
     final uri = Uri.parse(
         "https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$policy/${Constants.userGetTokenUrlEnding}");
 
     final response = await http.post(uri, body: {
       'grant_type': Constants.refreshToken,
-      'scope': Constants.defaultScopes,
+      'scope': providedScopes,
       'client_id': clientId,
       'refresh_token': refreshToken,
     }, headers: {


### PR DESCRIPTION
This PR makes it possible to add custom scopes when refreshing a token.

**What's new:**
- [x] Bug Fixes: Added optional parameter `providedScopes` to `refreshTokens` method. If not provided, it will take the default `Constants.defaultScopes`.

**This PR resolves the following issue:**
https://github.com/microsoft/aad_b2c_webview/issues/47