### PR TITLE
Check mounted property before invoking context getter

### DIFF
--- a/lib/src/presentation/pages/ad_b2c_webview.dart
+++ b/lib/src/presentation/pages/ad_b2c_webview.dart
@@ -17,8 +17,7 @@ class ADLoginWebView extends StatefulWidget {
   State<ADLoginWebView> createState() => _ADLoginWebViewState();
 }
 
-class _ADLoginWebViewState extends State<ADLoginWebView>
-    with MixinControllerAccess {
+class _ADLoginWebViewState extends State<ADLoginWebView> with MixinControllerAccess {
   @override
   void initState() {
     _initWebview();
@@ -40,7 +39,9 @@ class _ADLoginWebViewState extends State<ADLoginWebView>
   }
 
   _onLoadComponents(_) {
-    widget.settings?.controllerBuilder(context, actionController);
+    if (mounted) {
+      widget.settings?.controllerBuilder(context, actionController);
+    }
   }
 
   _onSuccess({
@@ -48,11 +49,15 @@ class _ADLoginWebViewState extends State<ADLoginWebView>
     required TokenEntity idToken,
     required TokenEntity refreshToken,
   }) {
-    widget.settings?.onSuccess(context, accessToken, idToken, refreshToken);
+    if (mounted) {
+      widget.settings?.onSuccess(context, accessToken, idToken, refreshToken);
+    }
   }
 
   _onError(String message) {
-    widget.settings?.onError(context, message);
+    if (mounted) {
+      widget.settings?.onError(context, message);
+    }
   }
 
   Widget _buildMobile() => WebViewWidget(


### PR DESCRIPTION
This error occurs if the `onError` callback is invoked after the ADLoginWebView is removed from the Widget Tree due to a navigation action (as in my use case).

Error:
```
E/flutter (10694): [ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: This widget has been unmounted, so the State no longer has a context (and should be considered defunct).
E/flutter (10694): Consider canceling any active work during "dispose" or using the "mounted" getter to determine if the State is still active.
E/flutter (10694): #0      State.context.<anonymous closure> (package:flutter/src/widgets/framework.dart:954:9)
E/flutter (10694): #1      State.context (package:flutter/src/widgets/framework.dart:960:6)
E/flutter (10694): #2      _ADLoginWebViewState._onError (package:aad_b2c_webview/src/presentation/pages/ad_b2c_webview.dart:55:30)
E/flutter (10694): #3      B2CWebViewDatasourceImpl._pollUntilPageLoaded (package:aad_b2c_webview/src/data/datasources/remote/b2c_webview_datasource_impl.dart:128:30)
E/flutter (10694): <asynchronous suspension>
E/flutter (10694): #4      B2CWebViewDatasourceImpl.initializeMobile.<anonymous closure> (package:aad_b2c_webview/src/data/datasources/remote/b2c_webview_datasource_impl.dart:80:17)
E/flutter (10694): <asynchronous suspension>
E/flutter (10694): 
```

Snippet for my use case:
```Dart
void _onSuccess(
    BuildContext context,
    TokenEntity? accessToken,
    TokenEntity? idToken,
    TokenEntity? refreshToken,
  ) {
    var snackBar = const SnackBar(
      content: Text('Successfully Authenticated!'),
      backgroundColor: Colors.green,
    );

    Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (_) => LoggedPage()));
  }
```